### PR TITLE
Update minimum cmake version

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 


### PR DESCRIPTION
Summary:
PT and submodules (e.g. fbgemm) use 3.5 as a mininum required version.

Test Plan:
Building locally with downgraded cmake